### PR TITLE
Add PR validation workflow for automated build and test

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,43 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+  merge_group:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore tests/Plugin.Maui.OfflineData.Tests/Plugin.Maui.OfflineData.Tests.csproj
+
+      - name: Build solution
+        run: dotnet build tests/Plugin.Maui.OfflineData.Tests/Plugin.Maui.OfflineData.Tests.csproj --no-restore --configuration Release
+
+      - name: Run tests
+        run: dotnet test tests/Plugin.Maui.OfflineData.Tests/Plugin.Maui.OfflineData.Tests.csproj --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=test-results.trx"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: '**/TestResults/*.trx'
+          retention-days: 30


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for validating pull requests. The workflow automates the build and test process for the `Plugin.Maui.OfflineData` project, ensuring code quality and providing feedback directly on pull requests.

**CI/CD Automation:**

* Added a new workflow file `.github/workflows/pr-validation.yaml` that triggers on pull requests, merge groups, and manual dispatches.
* The workflow checks out the code, sets up the .NET 9 environment, restores dependencies, builds the test project, runs the tests, and uploads test results as artifacts for review.
* Configured permissions to allow the workflow to read contents and write to pull requests, enabling integration with GitHub PR checks.